### PR TITLE
Remove UIAlertView and UIActionSheet method for iOS7

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -64,38 +64,26 @@ class ViewController: UITableViewController {
     // MARK: - Actions
     
     @IBAction func leftBarButtonItemTapped(sender: AnyObject) {
-        
-        if (NSClassFromString("UIAlertController") != nil) {
-            let alert = UIAlertView(title: "Alert", message: "In this case, your tap is visible.", delegate: nil, cancelButtonTitle: "OK")
-            alert.show()
-        } else {
-            let controller = UIAlertController(
-                title: "Alert",
-                message: "In this case, your tap is visible.",
-                preferredStyle: .ActionSheet
-            )
-            controller.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
-            self.presentViewController(controller, animated: true, completion: nil)
-        }
+        let controller = UIAlertController(
+            title: "Alert",
+            message: "Even when alert shows, your tap is visible.",
+            preferredStyle: .Alert
+        )
+        controller.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
+        self.presentViewController(controller, animated: true, completion: nil)
     }
     
     @IBAction func rightBarButtonItemTapped(sender: AnyObject) {
-        if (NSClassFromString("UIAlertController") != nil) {
-            let actionSheet = UIActionSheet(title: "ActionSheet", delegate: nil, cancelButtonTitle: "Cancel", destructiveButtonTitle: nil, otherButtonTitles: "Action(0)", "Action(1)", "Action(2)")
-            actionSheet.showInView(self.view)
-        } else {
-            let controller = UIAlertController(
-                title: "ActionSheet",
-                message: "In this case, your tap is visible.",
-                preferredStyle: .ActionSheet
-            )
-            for i in 0..<3 {
-                controller.addAction(UIAlertAction(title: "Action(\(i))", style: .Default, handler: nil))
-            }
-            controller.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
-            self.presentViewController(controller, animated: true, completion: nil)
+        let controller = UIAlertController(
+            title: "ActionSheet",
+            message: "Even when action sheet shows, your tap is visible.",
+            preferredStyle: .ActionSheet
+        )
+        for i in 0..<3 {
+            controller.addAction(UIAlertAction(title: "Action(\(i))", style: .Default, handler: nil))
         }
-        
+        controller.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
+        self.presentViewController(controller, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
Remove iOS7 compatibility. Because this repo is in experimental and unstable compatibility is not well.

refs. https://github.com/morizotter/TouchVisualizer/issues/7
