### PR TITLE
Add getTouches() in Visualizer extension for getting touch locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ and stop the presentation like this:
 ```swift
 Visualizer.stop()
 ```
+Get touch locations by this:
+
+```swift
+Visualizer.getTouches()
+```
 
 It is really simple, isn't it?
 

--- a/TouchVisualizer/Visualizer.swift
+++ b/TouchVisualizer/Visualizer.swift
@@ -88,6 +88,15 @@ extension Visualizer {
         }
     }
     
+    public class func getTouches() -> [UITouch] {
+        let instance = sharedInstance
+        var touches: [UITouch] = []
+        for view in instance.touchViews {
+            touches.append(view.touch!)
+        }
+        return touches
+    }
+    
     // MARK: - Dequeue and locating TouchViews and handling events
     private func dequeueTouchView() -> TouchView {
         var touchView: TouchView?


### PR DESCRIPTION
Hi, morizotter!
I am using your framework TouchVisualizer in my app. But I found that I cannot get the touch locations from your framework. So I add a method called getTouches() in your extension to get touch locations.
Hope you can accept this pull request, and update your CocoaPods version so that I can download it from CocoaPods directly.
Best wishes!